### PR TITLE
more explicit error messages

### DIFF
--- a/src/main/java/net/researchgate/azkaban/LdapUserManager.java
+++ b/src/main/java/net/researchgate/azkaban/LdapUserManager.java
@@ -103,7 +103,7 @@ public class LdapUserManager implements UserManager {
 
             return user;
         } catch (LdapException e) {
-            throw new UserManagerException("LDAP error", e);
+            throw new UserManagerException("LDAP error: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new UserManagerException("IO error", e);
         } catch (CursorException e) {


### PR DESCRIPTION
Difficult to debug without a more explicit error message when we have it deployed. 