### PR TITLE
Add groups/roles support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 repositories {
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()
+    maven { url "https://jitpack.io" }
 }
 
 configurations {
@@ -14,10 +14,10 @@ configurations {
 }
 
 dependencies {
-    provided group: 'com.linkedin.azkaban', name: 'azkaban', version: '2.5.0'
-    compile group: 'org.apache.directory.api', name: 'api-all', version: '1.0.0-M31'
+    provided 'com.github.azkaban:azkaban:3.5.0'
+    compile 'org.apache.directory.api:api-all:1.0.0-M31'
 
-    testCompile group: 'junit', name: 'junit', version: '4.8.+'
+    testCompile 'junit:junit:4.8.+'
 }
 
 jar {

--- a/src/main/java/net/researchgate/azkaban/Group.java
+++ b/src/main/java/net/researchgate/azkaban/Group.java
@@ -1,0 +1,43 @@
+package net.researchgate.azkaban;
+
+import azkaban.user.Role;
+import azkaban.user.User;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A group to which Azkaban users belong to.
+ * It is used to map groups from the XML file.
+ */
+class Group {
+
+    private String name;
+    private List<Role> roles;
+
+    Group(String name) {
+        this.name = name;
+        this.roles = new ArrayList<>();
+    }
+
+    String getName() {
+        return name;
+    }
+
+    void addRole(Role role) {
+        roles.add(role);
+    }
+
+    List<Role> getRoles() {
+        return Collections.unmodifiableList(roles);
+    }
+
+    void assignRolesToUser(User user) {
+        for (Role role : roles) {
+            if (!user.hasRole(role.getName())) {
+                user.addRole(role.getName());
+            }
+        }
+    }
+}

--- a/src/main/java/net/researchgate/azkaban/GroupsLoader.java
+++ b/src/main/java/net/researchgate/azkaban/GroupsLoader.java
@@ -1,0 +1,176 @@
+package net.researchgate.azkaban;
+
+import azkaban.user.Permission;
+import azkaban.user.Role;
+import org.w3c.dom.*;
+import org.xml.sax.*;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Loads groups from an XML file.
+ */
+class GroupsLoader {
+
+    private static final String DEFAULT_ROLE_NAME = "admin";
+    private static final String XML_DTD_FILE_PATH = "/azkaban-groups.dtd";
+
+    Map<String, Group> loadFromFile(String filePath) {
+        File file = loadFile(filePath);
+        Document document = loadDocument(file);
+
+        if (document == null) {
+            return null;
+        }
+
+        NodeList nodes = document.getChildNodes();
+        Element rootElement = (Element)nodes.item(1);
+
+        Map<String, Role> roles = parseRoles(rootElement);
+
+        Map<String, Group> groups = parseGroups(rootElement, roles);
+
+        return Collections.unmodifiableMap(groups);
+    }
+
+    Map<String, Group> loadFromList(List<String> list) {
+        Map<String, Group> groups = new HashMap<>();
+
+        for (String groupName : list) {
+            Permission permission = new Permission(Permission.Type.ADMIN);
+
+            Role role = new Role(DEFAULT_ROLE_NAME, permission);
+
+            Group group = new Group(groupName);
+            group.addRole(role);
+
+            groups.put(group.getName(), group);
+        }
+
+        return Collections.unmodifiableMap(groups);
+    }
+
+    private Map<String, Role> parseRoles(Element rootElement) {
+        NodeList roleNodes = rootElement.getElementsByTagName("role");
+        Map<String, Role> roles = new HashMap<>();
+
+        for (int i = 0; i < roleNodes.getLength(); i++) {
+            NamedNodeMap attributes = roleNodes.item(i).getAttributes();
+            Node nameAttribute = attributes.getNamedItem("name");
+            Node permissionsAttribute = attributes.getNamedItem("permissions");
+
+            Permission permission = new Permission();
+
+            permission.addPermissionsByName(
+                    permissionsAttribute.getNodeValue().split("\\s+")
+            );
+
+            String roleName = nameAttribute.getNodeValue();
+
+            Role role = new Role(roleName, permission);
+            roles.put(roleName, role);
+        }
+
+        return roles;
+    }
+
+    private Map<String, Group> parseGroups(Element rootElement, Map<String, Role> roles) {
+        NodeList groupNodes = rootElement.getElementsByTagName("group");
+        Map<String, Group> groups = new HashMap<>();
+
+        for (int i = 0; i < groupNodes.getLength(); i++) {
+            NamedNodeMap attributes = groupNodes.item(i).getAttributes();
+            Node nameNode = attributes.getNamedItem("name");
+            Node rolesNode = attributes.getNamedItem("roles");
+
+            String groupName = nameNode.getNodeValue();
+
+            Group group = new Group(groupName);
+
+            String[] roleNames = rolesNode.getNodeValue().split("\\s+");
+
+            for (String roleName : roleNames) {
+                Role role = roles.get(roleName);
+                group.addRole(role);
+            }
+
+            groups.put(groupName, group);
+        }
+
+        return groups;
+    }
+
+    private File loadFile(String path) {
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("Groups file can not be empty.");
+        }
+
+        File file = new File(path);
+
+        if (!file.exists()) {
+            throw new IllegalArgumentException(
+                    String.format("Groups file does not exists: '%s'", path)
+            );
+        }
+
+        return file;
+    }
+
+    private Document loadDocument(File file) {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setValidating(true);
+
+        DocumentBuilder builder;
+
+        try {
+            builder = factory.newDocumentBuilder();
+        } catch (ParserConfigurationException exception) {
+            throw new IllegalArgumentException(
+                    "Exception while parsing user xml. Document builder not created.", exception);
+        }
+
+        builder.setEntityResolver(new EntityResolver() {
+            @Override
+            public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+                return new InputSource(getClass().getResourceAsStream(XML_DTD_FILE_PATH));
+            }
+        });
+
+        builder.setErrorHandler(new ErrorHandler() {
+            @Override
+            public void warning(SAXParseException exception) throws SAXException {
+                throw new IllegalArgumentException(
+                        String.format("Xml file is malformed: '%s'", exception.toString()));
+            }
+
+            @Override
+            public void error(SAXParseException exception) throws SAXException {
+                throw new IllegalArgumentException(
+                        String.format("Xml file is malformed: '%s'", exception.toString()));
+            }
+
+            @Override
+            public void fatalError(SAXParseException exception) throws SAXException {
+                exception.printStackTrace();throw new IllegalArgumentException(
+                        String.format("Xml file is malformed: '%s'", exception.toString()));
+            }
+        });
+
+        Document document;
+
+        try {
+            document = builder.parse(file);
+        } catch (SAXException | IOException exception) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid XML: '%s'", file),
+                    exception);
+        }
+
+        return document;
+    }
+}

--- a/src/main/resources/azkaban-groups.dtd
+++ b/src/main/resources/azkaban-groups.dtd
@@ -1,0 +1,13 @@
+<!ELEMENT azkaban-groups (groups,roles)>
+
+<!ELEMENT groups (group)+>
+<!ELEMENT group EMPTY>
+<!ATTLIST group
+        name ID #REQUIRED
+        roles IDREFS #REQUIRED>
+
+<!ELEMENT roles (role)+>
+<!ELEMENT role EMPTY>
+<!ATTLIST role
+        name ID #REQUIRED
+        permissions CDATA #REQUIRED>

--- a/src/test/java/net/researchgate/azkaban/GroupsLoaderTest.java
+++ b/src/test/java/net/researchgate/azkaban/GroupsLoaderTest.java
@@ -1,0 +1,105 @@
+package net.researchgate.azkaban;
+
+import azkaban.user.Permission;
+import azkaban.user.Role;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class GroupsLoaderTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFilePathIsNull() {
+        GroupsLoader loader = new GroupsLoader();
+        loader.loadFromFile(null);
+
+        fail("GroupsLoader should throw an exception when a `null` file path is provided");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFilePathIsEmpty() {
+        GroupsLoader loader = new GroupsLoader();
+        loader.loadFromFile("");
+
+        fail("GroupsLoader should throw an exception when an empty no file path is provided");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFileDoesNotExists() {
+        GroupsLoader loader = new GroupsLoader();
+        loader.loadFromFile("does-not-exists.xml");
+
+        fail("GroupsLoader should throw an exception when the file doesn't exist");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFileIsMalformed() {
+        String filePath = getClass().getResource("/azkaban-groups-malformed.xml").getFile();
+        GroupsLoader loader = new GroupsLoader();
+        loader.loadFromFile(filePath);
+
+        fail("GroupsLoader should throw an exception when the file is malformed");
+    }
+
+    @Test
+    public void testValidFile() {
+        String filePath = getClass().getResource("/azkaban-groups.xml").getFile();
+        GroupsLoader loader = new GroupsLoader();
+        loader.loadFromFile(filePath);
+    }
+
+    @Test
+    public void testLoadGroupsFromFile() {
+        String filePath = getClass().getResource("/azkaban-groups.xml").getFile();
+        GroupsLoader loader = new GroupsLoader();
+        Map<String, Group> groups = loader.loadFromFile(filePath);
+
+        assertEquals(3, groups.size());
+
+        Group mathematiciansGroup = groups.get("mathematicians");
+        List<Role> mathematiciansRoles = mathematiciansGroup.getRoles();
+
+        assertEquals(1, mathematiciansRoles.size());
+        assertEquals("administrator", mathematiciansRoles.get(0).getName());
+        assertTrue(mathematiciansRoles.get(0).getPermission().isPermissionSet(Permission.Type.ADMIN));
+
+        Group scientistsGroup = groups.get("scientists");
+        List<Role> scientistsRoles = scientistsGroup.getRoles();
+        Permission vieuwerPermission = scientistsRoles.get(0).getPermission();
+        Permission executorPermission = scientistsRoles.get(1).getPermission();
+
+        assertEquals(2, scientistsRoles.size());
+        assertTrue(vieuwerPermission.isPermissionSet(Permission.Type.READ));
+        assertTrue(executorPermission.isPermissionSet(Permission.Type.WRITE));
+        assertTrue(executorPermission.isPermissionSet(Permission.Type.EXECUTE));
+
+        Group viewersGroup = groups.get("viewers");
+        List<Role> viewersRoles = viewersGroup.getRoles();
+        Permission viewerPermission = viewersRoles.get(0).getPermission();
+
+        assertEquals(2, scientistsRoles.size());
+        assertTrue(viewerPermission.isPermissionSet(Permission.Type.READ));
+    }
+
+    @Test
+    public void testLoadGroupsFromList() {
+        List<String> groupNames = new ArrayList<>();
+        groupNames.add("mathematicians");
+        groupNames.add("scientists");
+
+        GroupsLoader loader = new GroupsLoader();
+        Map<String, Group> groups = loader.loadFromList(groupNames);
+
+        assertEquals(2, groups.size());
+
+        Group group = groups.get("mathematicians");
+        Role role = group.getRoles().get(0);
+
+        assertEquals("admin", role.getName());
+        assertTrue("admin", role.getPermission().isPermissionSet(Permission.Type.ADMIN));
+    }
+}

--- a/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
+++ b/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
@@ -34,8 +34,9 @@ public class LdapUserManagerTest {
         props.put(LdapUserManager.LDAP_EMAIL_PROPERTY, "mail");
         props.put(LdapUserManager.LDAP_BIND_ACCOUNT, "cn=read-only-admin,dc=example,dc=com");
         props.put(LdapUserManager.LDAP_BIND_PASSWORD, "password");
-        props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "");
+        props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "mathematicians");
         props.put(LdapUserManager.LDAP_GROUP_SEARCH_BASE, "dc=example,dc=com");
+        props.put(LdapUserManager.LDAP_GROUPS_FILE, getClass().getResource("/azkaban-groups.xml").getFile());
         return props;
     }
 
@@ -109,5 +110,35 @@ public class LdapUserManagerTest {
     public void testEscapeLDAPSearchFilter() throws Exception {
         assertEquals("No special characters to escape", "Hi This is a test #çà", userManager.escapeLDAPSearchFilter("Hi This is a test #çà"));
         assertEquals("LDAP Christams Tree", "Hi \\28This\\29 = is \\2a a \\5c test # ç à ô", userManager.escapeLDAPSearchFilter("Hi (This) = is * a \\ test # ç à ô"));
+    }
+
+    @Test
+    public void testUserIsMemberOfGroup() throws Exception {
+        Props props = getProps();
+        props.put(LdapUserManager.LDAP_ROLE_SUPPORT, "true");
+
+        userManager = new LdapUserManager(props);
+
+        User userRiemann = userManager.getUser("riemann", "password");
+        User userEinstein = userManager.getUser("einstein", "password");
+
+        assertTrue(userRiemann.getGroups().contains("mathematicians"));
+        assertTrue(userEinstein.getGroups().contains("scientists"));
+    }
+
+    @Test
+    public void testUserHasRoleAssigned() throws Exception {
+        Props props = getProps();
+        props.put(LdapUserManager.LDAP_ROLE_SUPPORT, "true");
+
+        userManager = new LdapUserManager(props);
+
+        User userRiemann = userManager.getUser("riemann", "password");
+        User userEinstein = userManager.getUser("einstein", "password");
+
+        assertTrue(userRiemann.hasRole("administrator"));
+
+        assertTrue(userEinstein.hasRole("viewer"));
+        assertTrue(userEinstein.hasRole("executor"));
     }
 }

--- a/src/test/resources/azkaban-groups-malformed.xml
+++ b/src/test/resources/azkaban-groups-malformed.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<!DOCTYPE azkaban-groups SYSTEM "azkaban-groups.dtd">
+<azkaban-groups>
+</azkaban-groups>

--- a/src/test/resources/azkaban-groups.xml
+++ b/src/test/resources/azkaban-groups.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE azkaban-groups SYSTEM "azkaban-groups.dtd">
+<azkaban-groups>
+    <groups>
+        <group name="mathematicians" roles="administrator" />
+        <group name="scientists" roles="viewer executor" />
+        <group name="viewers" roles="viewer" />
+    </groups>
+
+    <roles>
+        <role name="administrator" permissions="ADMIN" />
+        <role name="executor" permissions="WRITE EXECUTE" />
+        <role name="viewer" permissions="READ" />
+    </roles>
+</azkaban-groups>


### PR DESCRIPTION
First attempt to add groups/roles support.

The Roles are defined in Azkaban and the users in LDAP. The groups connects users to roles.

Groups and roles are defined in an XML file, similar to the `azkaban-users.xml` file.
