### PR TITLE
fix for issue #8, LDAP server connection leak causing spurious high C…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.log
 *.iml
 *.ipr
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ configurations {
 dependencies {
     provided group: 'com.linkedin.azkaban', name: 'azkaban', version: '2.5.0'
     compile group: 'org.apache.directory.api', name: 'api-all', version: '1.0.0-M31'
+    compile group: 'log4j', name: 'log4j', version: '1.2.16'
 
     testCompile group: 'junit', name: 'junit', version: '4.8.+'
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=INFO, Console
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] [Azkaban] %m%n


### PR DESCRIPTION
This code fixes the LDAP connection leak. The original code leaks LDAP connections causing high CPU consumption because it creates a number of NioProcessor threads that run forever consuming the CPU for no reason. This happens when LDAP connections are not properly closed, because azkaban-ldap-plugin invokes org.apache.directory, which in turn invokes org.apache.mina. 

Closing the connections in the finally block resolves the issue. Initializing the object to null outside the "try" block enables us to only close the connection if it has been created (i.e. is not null) thus avoiding a null pointer exception.