### PR TITLE
Add groupOfNames support (if not exist memberOf in userAttribute)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8

--- a/src/main/java/net/researchgate/azkaban/LdapUserManager.java
+++ b/src/main/java/net/researchgate/azkaban/LdapUserManager.java
@@ -184,18 +184,37 @@ public class LdapUserManager implements UserManager {
                     return false;
                 }
 
-                Attribute members = result.get("memberuid");
-                if (members == null) {
-                    logger.info("Could not get members of group '" + expectedGroup + "'. Not checking further groups.");
-                    return false;
-                }
+                Attribute objectClasses = result.get("objectClass");
+                if(objectClasses != null && objectClasses.contains("groupOfNames")) {
+                    Attribute members = result.get("member");
 
-                boolean isMember = members.contains(username);
-                logger.info("Searched for username '" + username + "' " +
-                        "within group members of group '" + expectedGroupName + "'. " +
-                        "User is member: " + isMember);
-                if (isMember) {
-                    return true;
+                    if (members == null) {
+                        logger.info("Could not get members of group '" + expectedGroup + "'. Not checking further groups.");
+                        return false;
+                    }
+
+                    String userDn = "cn=" + username + "," + ldapUserBase;
+                    boolean isMember = members.contains(userDn);
+                    logger.info("Searched for userDn '" + userDn + "' " +
+                            "within group members of group '" + expectedGroupName + "'. " +
+                            "User is member: " + isMember);
+                    if (isMember) {
+                        return true;
+                    }
+                } else {
+                    Attribute members = result.get("memberuid");
+                    if (members == null) {
+                        logger.info("Could not get members of group '" + expectedGroup + "'. Not checking further groups.");
+                        return false;
+                    }
+
+                    boolean isMember = members.contains(username);
+                    logger.info("Searched for username '" + username + "' " +
+                            "within group members of group '" + expectedGroupName + "'. " +
+                            "User is member: " + isMember);
+                    if (isMember) {
+                        return true;
+                    }
                 }
             }
             return false;

--- a/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
+++ b/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
@@ -73,6 +73,19 @@ public class LdapUserManagerTest {
     }
 
     @Test
+    public void testGetUserWithAllowedGroupThatGroupOfNames() throws Exception {
+        Props props = getProps();
+        props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "svc-test2");
+        final LdapUserManager manager = new LdapUserManager(props);
+
+        User user = manager.getUser("gauss", "password");
+
+        assertEquals("gauss", user.getUserId());
+        assertEquals("gauss@ldap.example.com", user.getEmail());
+    }
+
+
+    @Test
     public void testGetUserWithEmbeddedGroup() throws Exception {
         Props props = getProps();
         props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "svc-test");

--- a/src/test/resources/default.ldif
+++ b/src/test/resources/default.ldif
@@ -24,3 +24,9 @@ objectClass: top
 objectClass: posixGroup
 cn: svc-test
 memberUid: gauss
+
+dn: cn=svc-test2,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: svc-test2
+member: cn=gauss,dc=example,dc=com


### PR DESCRIPTION
When I used group that's objectClass is `groupOfNames`
and used `user.manager.ldap.embeddedGroups=false` property,
user cannot login.
My case,  userAttribute didn't have memberOf.