### PR TITLE
Add xml auth

### DIFF
--- a/azkaban-users.xml
+++ b/azkaban-users.xml
@@ -1,0 +1,11 @@
+<azkaban-users>
+    <user username="azkaban" password="azkaban" roles="admin" groups="admin" />
+
+    <role name="admin" permissions="ADMIN" />
+    <role name="metrics" permissions="METRICS"/>
+    <role name="read" permissions="READ"/>
+    <role name="write" permissions="WRITE"/>
+    <role name="execute" permissions="EXECUTE"/>
+    <role name="schedule" permissions="SCHEDULE"/>
+    <role name="staff" permissions="READ"/>
+</azkaban-users>

--- a/azkaban-users.xml
+++ b/azkaban-users.xml
@@ -1,11 +1,7 @@
 <azkaban-users>
-    <user username="azkaban" password="azkaban" roles="admin" groups="admin" />
+    <user username="admin" password="c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec" roles="admin" />
+    <user username="read" password="ee021c5aa94c55f1dbbe287200618d386799f21ce4e35af71c9e7474267ebaf5fde5436ea44d689c8abd9dbb24e76da9493f982453cad987d1ca003f9eb9ef34" roles="read" />
 
     <role name="admin" permissions="ADMIN" />
-    <role name="metrics" permissions="METRICS"/>
     <role name="read" permissions="READ"/>
-    <role name="write" permissions="WRITE"/>
-    <role name="execute" permissions="EXECUTE"/>
-    <role name="schedule" permissions="SCHEDULE"/>
-    <role name="staff" permissions="READ"/>
 </azkaban-users>

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ shadowJar {
 jar.enabled = false
 
 dependencies {
-    compileOnly group: 'com.github.azkaban', name: 'azkaban', version: '3.16.0'
+    compileOnly group: 'com.github.azkaban', name: 'azkaban', version: '3.57.0'
     compile group: 'org.apache.directory.api', name: 'api-all', version: '1.0.0-M31'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.5.2'
-    testCompile group: 'com.github.azkaban', name: 'azkaban', version: '3.16.0'
+    testCompile group: 'com.github.azkaban', name: 'azkaban', version: '3.57.0'
 }
 
 github {

--- a/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
+++ b/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
@@ -39,6 +39,9 @@ public class LdapUserManagerTest {
 
     private Props getProps() {
         Props props = new Props();
+
+        props.put(LdapUserManager.XML_FILE_PARAM, "azkaban-users.xml");
+
         props.put(LdapUserManager.LDAP_HOST, "localhost");
         props.put(LdapUserManager.LDAP_PORT, "11389");
         props.put(LdapUserManager.LDAP_USE_SSL, "false");

--- a/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
+++ b/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
@@ -4,6 +4,7 @@ import azkaban.user.Role;
 import azkaban.user.User;
 import azkaban.user.UserManagerException;
 import azkaban.utils.Props;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,20 +52,47 @@ public class LdapUserManagerTest {
         props.put(LdapUserManager.LDAP_BIND_ACCOUNT, "cn=read-only-admin,dc=example,dc=com");
         props.put(LdapUserManager.LDAP_BIND_PASSWORD, "password");
         props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "");
+        props.put(LdapUserManager.LDAP_ADMIN_GROUPS, "admin");
         props.put(LdapUserManager.LDAP_GROUP_SEARCH_BASE, "dc=example,dc=com");
         return props;
     }
 
     @Test
-    public void testGetUser() throws Exception {
-        User user = userManager.getUser("gauss", "password");
+    public void testGetXmlAdminUser() throws Exception {
+        User user = userManager.getUser("admin", "admin");
+        List <String> roles = user.getRoles();
+        Role role = userManager.getRole(roles.get(0));
 
-        assertEquals("gauss", user.getUserId());
-        assertEquals("gauss@ldap.example.com", user.getEmail());
+        assertEquals("admin", user.getUserId());
+        assertEquals(1, roles.size());
+        assertTrue(role.getPermission().isPermissionNameSet("ADMIN"));
     }
 
     @Test
-    public void testGetUserWithAllowedGroup() throws Exception {
+    public void testGetXmlReadUser() throws Exception {
+        User user = userManager.getUser("read", "read");
+        List <String> roles = user.getRoles();
+        Role role = userManager.getRole(roles.get(0));
+
+        assertEquals("read", user.getUserId());
+        assertEquals(1, roles.size());
+        assertTrue(role.getPermission().isPermissionNameSet("READ"));
+    }
+
+    @Test
+    public void testGetLdapUser() throws Exception {
+        User user = userManager.getUser("gauss", "password");
+        List <String> roles = user.getRoles();
+        Role role = userManager.getRole(roles.get(0));
+
+        assertEquals("gauss", user.getUserId());
+        assertEquals("gauss@ldap.example.com", user.getEmail());
+        assertEquals(1, roles.size());
+        assertTrue(role.getPermission().isPermissionNameSet("READ"));
+    }
+
+    @Test
+    public void testGetLdapUserWithAllowedGroup() throws Exception {
         Props props = getProps();
         props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "svc-test");
         final LdapUserManager manager = new LdapUserManager(props);
@@ -76,7 +104,7 @@ public class LdapUserManagerTest {
     }
 
     @Test
-    public void testGetUserWithAllowedGroupThatGroupOfNames() throws Exception {
+    public void testGetLdapUserWithAllowedGroupThatGroupOfNames() throws Exception {
         Props props = getProps();
         props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "svc-test2");
         final LdapUserManager manager = new LdapUserManager(props);
@@ -89,7 +117,7 @@ public class LdapUserManagerTest {
 
 
     @Test
-    public void testGetUserWithEmbeddedGroup() throws Exception {
+    public void testGetLdapUserWithEmbeddedGroup() throws Exception {
         Props props = getProps();
         props.put(LdapUserManager.LDAP_ALLOWED_GROUPS, "svc-test");
         props.put(LdapUserManager.LDAP_EMBEDDED_GROUPS, "true");
@@ -102,25 +130,25 @@ public class LdapUserManagerTest {
     }
 
     @Test
-    public void testGetUserWithInvalidPasswordThrowsUserManagerException() throws Exception {
+    public void testGetLdapUserWithInvalidPasswordThrowsUserManagerException() throws Exception {
         thrown.expect(UserManagerException.class);
         userManager.getUser("gauss", "invalid");
     }
 
     @Test
-    public void testGetUserWithInvalidUsernameThrowsUserManagerException() throws Exception {
+    public void testGetLdapUserWithInvalidUsernameThrowsUserManagerException() throws Exception {
         thrown.expect(UserManagerException.class);
         userManager.getUser("invalid", "password");
     }
 
     @Test
-    public void testGetUserWithEmptyPasswordThrowsUserManagerException() throws Exception {
+    public void testGetLdapUserWithEmptyPasswordThrowsUserManagerException() throws Exception {
         thrown.expect(UserManagerException.class);
         userManager.getUser("gauss", "");
     }
 
     @Test
-    public void testGetUserWithEmptyUsernameThrowsUserManagerException() throws Exception {
+    public void testGetLdapUserWithEmptyUsernameThrowsUserManagerException() throws Exception {
         thrown.expect(UserManagerException.class);
         userManager.getUser("", "invalid");
     }


### PR DESCRIPTION
Hello,
This proposed change main purpose is to enable authentication with XML users file in addition to LDAP authentication.
I've also made the following changes:
- set azkaban version to 3.57.0
- for LDAP auth: add "read" role to user
- for XML auth: store SHA-512 checksums rather than clear text passwords in XML users file
Regards,
Christophe.