### PR TITLE
Add support for TLS and self-signed certs

### DIFF
--- a/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
+++ b/src/test/java/net/researchgate/azkaban/LdapUserManagerTest.java
@@ -41,7 +41,6 @@ public class LdapUserManagerTest {
         Props props = new Props();
         props.put(LdapUserManager.LDAP_HOST, "localhost");
         props.put(LdapUserManager.LDAP_PORT, "11389");
-        props.put(LdapUserManager.LDAP_USE_SSL, "false");
         props.put(LdapUserManager.LDAP_USER_BASE, "dc=example,dc=com");
         props.put(LdapUserManager.LDAP_USERID_PROPERTY, "uid");
         props.put(LdapUserManager.LDAP_EMAIL_PROPERTY, "mail");


### PR DESCRIPTION
This change enables two things:

1. TLS encryption, controlled with the config param `user.manager.ldap.useTls`.
2. Support for self-signed server-side certs, controlled with the config param `user.manager.ldap.disableCertVerification`.